### PR TITLE
Adding eidList

### DIFF
--- a/EntityFu.cpp
+++ b/EntityFu.cpp
@@ -180,7 +180,7 @@ void Entity::removeComponent(Eid eid, Cid cid)
 		Log("Removing component cid %u eid %u (%x)", cid, eid, (int)(long)ptr);
 	}
 
-	auto it = find(eidList[cid]->begin(), eidList[cid]->end(), eid);
+	auto it = std::find(eidList[cid]->begin(), eidList[cid]->end(), eid);
 	if (it != eidList[cid]->end()) // just in case, should never be false
 		eidList[cid]->erase(it);
 

--- a/EntityFu.h
+++ b/EntityFu.h
@@ -78,7 +78,7 @@ class Entity
 		}
 		
 		template<class ComponentClass> static std::vector<Eid> const & getEidList() {
-			return *Entity::eidList[ComponentClass::cid];
+			return *Entity::eidList.at(ComponentClass::cid);
 		}
 
 		/// Create an entity with some components.

--- a/EntityFu.h
+++ b/EntityFu.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <vector>
+
 /// An `Eid` is an entity ID.
 typedef unsigned Eid;
 
@@ -30,19 +32,13 @@ class Entity
 		static Eid create();
 
 		/// Return a count of all entities.
-		static int count();
+		static size_t count();
 	
 		/// Destroy an entity and all its components right now.
 		static void destroyNow(Eid eid);
 	
 		/// Destroy all entities and components right now.
 		static void destroyAll();
-	
-		/// Return the minimum `Eid` for the given `Cid`.
-		static Eid getMinEid(Cid cid);
-	
-		/// Return the maximum `Eid` for the given `Cid`.
-		static Eid getMaxEid(Cid cid);
 	
 		/// Add the given component to the given entity.
 		/// Note that components must be allocated with new.
@@ -76,9 +72,13 @@ class Entity
 		}
 	
 		/// Count all the entities with the given component class.
-		template<class ComponentClass> inline static int count()
+		template<class ComponentClass> inline static size_t count()
 		{
 			return Entity::count(ComponentClass::cid);
+		}
+		
+		template<class ComponentClass> static std::vector<Eid> const & getEidList() {
+			return *Entity::eidList[ComponentClass::cid];
 		}
 
 		/// Create an entity with some components.
@@ -163,14 +163,13 @@ class Entity
 		static void addComponent(Eid eid, Component* c, Cid cid);
 		static void removeComponent(Eid eid, Cid cid);
 		static Component* getComponent(Eid eid, Cid cid);
-		static int count(Cid cid);
+		static size_t count(Cid cid);
 		static void log(Cid cid);
 		static void logAll();
 
 		static bool* entities;
 		static Component*** components;
-		static Eid* minEids;
-		static Eid* maxEids;
+		static std::vector<std::vector<Eid>*> eidList;
 
 		/// Get a guaranteed reference to a component.
 		template<class ComponentClass> static ComponentClass& ref(ComponentClass* p)
@@ -180,11 +179,6 @@ class Entity
 			return s;
 		}
 };
-
-/// Loop over all the entities of a given component class.
-/// Use the variable `eid` to get the components.
-/// Ensure that the `eid` actually has the given component class with `Entity::hasComponent`, `Entity::getPointer` or `Entity::get`.
-#define forAllEntities(c) for (auto eid = Entity::getMinEid(c::cid), eidMax = Entity::getMaxEid(c::cid); eid <= eidMax; eid++)
 
 ///
 /// Component

--- a/EntityFu.h
+++ b/EntityFu.h
@@ -32,7 +32,7 @@ class Entity
 		static Eid create();
 
 		/// Return a count of all entities.
-		static size_t count();
+		static int count();
 	
 		/// Destroy an entity and all its components right now.
 		static void destroyNow(Eid eid);

--- a/main.cpp
+++ b/main.cpp
@@ -50,14 +50,12 @@ struct HealthSystem : System
 	static void tick(double fixedDelta)
 	{
 		// for this example, just decrement all health components each tick
-		forAllEntities(HealthComponent)
+	
+		// always use reference for list to avoid copy!!!
+		auto const & list = Entity::getEidList<HealthComponent>();
+		for (auto && eid : list)
 		{
 			Ent e(eid);
-			
-			// always double check the `eid` is good because sometimes it is necessary for
-			// `forAllEntities` to loop over a range that doesn't have active entities
-			if (e.health.isEmpty())
-				continue;
 			
 			// decrement
 			e.health.hp--;
@@ -85,6 +83,7 @@ int main(int argc, const char * argv[])
 		usleep(1000 * 100);
 	}
 	
+	Entity::dealloc();
 	cout << "Goodbye, World!\n";
     return 0;
 }


### PR DESCRIPTION
Since your iterating a lot over the Entities, it might be faster to use separate lists for this purpose, 
Since `Entity::components` may have holes, you always have to check whether an entity is "good".

`addComponent()` and `removeComponent()` aren't called that often. So I think they can take the additional work that goes into managing these lists.

I'm using a `std::vector` here because AFAIK there is no performance difference between array and a `std::vector` if compiled with optimizations. 
I actually changed `Entity::components` and `Entity:entities` to `vector` in my own local version. But didn't commit those changes.

I'm NOT using `std::list` (which might be the obvious choice) because I found this interesting article http://baptiste-wicht.com/posts/2012/12/cpp-benchmark-vector-list-deque.html
`vector` is actually faster than `list` in most cases

SOME OTHER QUESTIONS:
Why does Eid start with 1? Obviously you were using 0 for marking an invalid entity or something similar, but this isn't implemented in EntityFu, I think.

Why does `Entity::dealloc()` avoid deleting the components? You're deleting them in `removeComponent()`. So `Entity` is in charge of the components...

BTW: I should definitely learn how to use Git... Right now I'm editing theses files on the website without testing them. So... there could be some typos... sorry.

So. What do you think? Is this useful? Please tell me, if there are performance improvements in "Songbringer".
