### PR TITLE
Fix compilation errors on Windows

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,13 @@
 
 #include "EntityFu.h"
 #include <iostream>
-#include <unistd.h>
+
+#ifdef _WIN32
+	#include <windows.h>
+#else // !_WIN32
+	#include <uinstd.h>
+#endif // _WIN32
+
 using namespace std;
 
 /// An example component.
@@ -88,7 +94,11 @@ int main(int argc, const char * argv[])
 	while (Entity::count())
 	{
 		HealthSystem::tick(0.1);
+#ifdef _WIN32
+		Sleep(100);
+#else // !_WIN32
 		usleep(1000 * 100);
+#endif // _WIN32
 	}
 	
 	Entity::dealloc();


### PR DESCRIPTION
This fixes the compilation errors on Windows that resulted from missing the uinstd.h header that doesn't ship with Windows compilers (as far as I tested, at least, using MSVC and MinGW/gcc). The error is solved by checking what system the user is on and including the correct header files for it.

The Sleep() function from windows.h handles time in milliseconds, and ergo the time was converted from microseconds (which usleep uses).

Tested on Windows 10 x64 & Arch Linux x64.
